### PR TITLE
Release 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tok-protocol"
-version = "0.1.0"
+version = "0.1.1"
 description = "Bridge-first CLI and runtime for Claude Code that compresses conversations and exposes savings and fallback health"
 authors = [
     { name = "tokmacher", email = "tokmacher@protonmail.com" }

--- a/src/tok/__init__.py
+++ b/src/tok/__init__.py
@@ -33,4 +33,4 @@ def __getattr__(name: str) -> object:
 
 __all__: list[str] = ["Bridge"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ from typing import Any, NoReturn
 
 from typer.testing import CliRunner
 
+from tok import __version__
 from tok.cli import app
 from tok.stats import SavingsTracker
 
@@ -34,7 +35,7 @@ class TestCLI:
     def test_version(self) -> None:
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert __version__ in result.output
 
     def test_version_shows_program_name(self) -> None:
         result = runner.invoke(app, ["--version"])

--- a/uv.lock
+++ b/uv.lock
@@ -1359,7 +1359,7 @@ wheels = [
 
 [[package]]
 name = "tok-protocol"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -1403,15 +1403,15 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "openai", specifier = ">=1.0.0,<2.0.0" },
+    { name = "openai", specifier = ">=1.0.0,<3.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<8.4.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0,<9.1.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.33.0" },
-    { name = "rich", specifier = ">=13.0.0,<14.0.0" },
+    { name = "rich", specifier = ">=13.0.0,<16.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "safety", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "tiktoken", specifier = ">=0.12.0,<1.0.0" },


### PR DESCRIPTION
# Summary

Patch release for `0.1.1`.

- Bumps package/runtime version from `0.1.0` to `0.1.1`
- Publishes the corrected bridge-first CLI surface already present on `main`
- Keeps `tok --version` covered by the CLI test without hard-coding the release number

## Testing

- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/test_cli.py -q -k 'version or help'`
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run --with twine python -m twine check dist/*`
- [x] Clean installed-wheel smoke: `tok --version` prints `tok 0.1.1`
- [x] Clean installed-wheel smoke: `tok --help` shows the bridge-first CLI surface

## Docs

- [x] README/docs unchanged; no first-run workflow change
- [x] PyPI metadata/artifacts updated via version bump

## Type of change

- [x] Bug fix
- [x] Release
