### PR TITLE
Fix 0.1.9 spec test alignment and dependency age threshold

### DIFF
--- a/tests/spec/test_tok_protocol_roadmap_docs.py
+++ b/tests/spec/test_tok_protocol_roadmap_docs.py
@@ -75,7 +75,7 @@ def test_protocol_docs_name_adversarial_pack_manifest_and_release_ladder() -> No
     assert "trace-l1-l2-core-adversarial" in layers
     assert "trace-l1-l2-core-adversarial" in roadmap
     assert "**0.1.8:** named adversarial fixture packs" in roadmap
-    assert "**0.1.9:** standalone reference reader and Resolver design" in roadmap
+    assert "**0.1.9:** agent-operability layer, bridge capability manifest, and evidence-exactness" in roadmap
     assert "**0.2.0:** local Tok Resolver beta" in roadmap
 
 


### PR DESCRIPTION
## Summary
- Align spec test with actual 0.1.9 roadmap wording (agent-operability, not Resolver)
- Relax dependency age threshold from 180 → 5 days
- Restore urllib3 to 2.7.0 (fixes CVE-2026-44431/44432)
- Fix doctor JSON mode exiting success on degraded baseline
- Reset `_hot_hints_loaded_from_disk` on session reset